### PR TITLE
Enable use_inline_resources in the provider

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -2,6 +2,8 @@ def whyrun_supported?
   true
 end
 
+use_inline_resources
+
 def tccutil(action, items)
   if platform_family?('mac_os_x')
     recipe_eval do


### PR DESCRIPTION
Thanks so much for writing this cookbook! I had written a similar but much uglier resource as part of the mac-app-store cookbook that now can go in the trash where it belongs! :)

One strange thing I was seeing... Normally you can call `.run_action` on a resource to make it converge immediately. I was doing something like...

```
macosx_accessibility 'a new thing' do
  items ['some stuff']
end.run_action(:insert)

<code that depends on the entry being inserted>
```

...inside my own custom provider and expecting the insert to happen right there. But that doesn't seem to be the case here.

If I'm reading the docs on [inline resources](https://docs.chef.io/lwrp_custom_provider.html#use-inline-resources) right, it's because the `execute` resource being declared inside is being sent to the top-level resource collection to be evaluated separately from the `macosx_accessibility` resource. Adding `use_inline_resources` results in the insert happening immediately (and all the tests still passing).

It's possible I'm doing silly things you don't want to support, but the docs mention this eventually being Chef's default behavior anyway. Thoughts?

Thanks!
